### PR TITLE
IR temp as K instead of C

### DIFF
--- a/flir2tif/Get_FLIR.py
+++ b/flir2tif/Get_FLIR.py
@@ -172,7 +172,7 @@ def rawData_to_temperature(rawData, scan_time, metadata):
         tc = np.zeros((640, 480))
         
         if calibP.calibrated:
-            tc = rawData/10 - 273.15
+            tc = rawData/10
         else:
             tc = flirRawToTemperature(rawData, calibP)
     


### PR DESCRIPTION
following standard units from CF conventions, I believe as specified by @zongyangli in https://github.com/terraref/reference-data/issues/182#issuecomment-327859158